### PR TITLE
SCI-819 - RoHS App Crashing due to FinalizerWatchdogDaemon timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 allprojects {
 
   group = 'com.dev-smart'
-  version = '0.4.2'
+  version = '0.4.3-SNAPSHOT'
   description = 'A embedded NoSQL Database'
 
   repositories {

--- a/microdb-runtime/build.gradle
+++ b/microdb-runtime/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'com.bmuschko.nexus'
+apply plugin: 'maven'
 
 
 dependencies {

--- a/microdb-runtime/src/main/java/com/devsmart/microdb/DBObject.java
+++ b/microdb-runtime/src/main/java/com/devsmart/microdb/DBObject.java
@@ -17,18 +17,6 @@ public class DBObject {
     private MicroDB mDB;
     protected boolean mDirty;
 
-    @Override
-    protected void finalize() throws Throwable {
-        try {
-            if (mDB != null) {
-                mDB.finalizing(this);
-            }
-
-        } finally {
-            super.finalize();
-        }
-    }
-
     protected void init(MicroDB microDB) {
         mDB = microDB;
     }

--- a/microdb-runtime/src/main/java/com/devsmart/microdb/MicroDB.java
+++ b/microdb-runtime/src/main/java/com/devsmart/microdb/MicroDB.java
@@ -404,25 +404,6 @@ public class MicroDB
         mDriver.commitTransaction();
     }
 
-
-    /**
-     * called when a dbobject is being finalized by the GC
-     *
-     * @param obj
-     */
-    protected void finalizing(DBObject obj)
-    {
-        if (mAutoSave.get() && obj.mDirty)
-        {
-            mWriteQueue.enqueue(createWriteObject(obj));
-        }
-        synchronized (this)
-        {
-            mLiveObjects.remove(obj.getId());
-        }
-
-    }
-
     public synchronized void close() throws IOException
     {
         flush();


### PR DESCRIPTION
- This deadlock was caused by lock contention on the object infinalize().  A synchronized method triggered a GC operation which resulted in finalize() being called with the lock held.  None of this processing is needed, and finalized is not guaranteed to be called anyhow, so I'm just removing this code.